### PR TITLE
FE-24 Feat : 업로드 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,7 +48,16 @@ function App() {
         <Route path='/login/setProfile' element={<SetProfile />} />
         <Route path='/search' element={<Search />} />
         <Route path='/yourProfile/:id' element={<YourProfile />} />
-        <Route path='/profile/:id' element={<MyProfile />} />
+        <Route
+          path='/profile/:id'
+          element={
+            isLoginState ? (
+              <MyProfile />
+            ) : (
+              <Navigate replace={true} to='/login' />
+            )
+          }
+        />
         <Route path='/profile/:id/edit' element={<MyProfileEdit />} />
         <Route path='/profile/:id/follower' element={<Followers />} />
         <Route
@@ -56,7 +65,16 @@ function App() {
           element={<MyProfileAddProduct />}
         />
         <Route path='/post/:post_id' element={<PostDetail />} />
-        <Route path='/upload' element={<PostUpload />} />
+        <Route
+          path='/upload'
+          element={
+            isLoginState ? (
+              <PostUpload />
+            ) : (
+              <Navigate replace={true} to='/login' />
+            )
+          }
+        />
         <Route path='/chat/list' element={<ChatList />} />
         <Route path='/chat/room' element={<ChatRoom />} />
       </Routes>

--- a/src/atoms.js
+++ b/src/atoms.js
@@ -66,3 +66,8 @@ export const searchUserData = atom({
   key: 'searchUserData',
   default: [],
 });
+
+export const uploadImgSrcAtom = atom({
+  key: 'uploadImgSrc',
+  default: '',
+});

--- a/src/components/modules/CustomFileInput/CustomFileInput.jsx
+++ b/src/components/modules/CustomFileInput/CustomFileInput.jsx
@@ -74,7 +74,7 @@ const CustomFileInput = () => {
         type='file'
         className='ir'
         id='profile-img'
-        accept='image/*'
+        accept='.jpg, *.gif, .png, .jpeg, .bmp, .tif, .heic'
         onChange={handleProfileImgInputOnchange}
       />
     </CustomFileInputWrapper>

--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -14,8 +14,11 @@ import {
   userIntroValue,
   usernameValue,
   searchUserData,
+  postTxtValue,
+  uploadImgSrcAtom,
 } from '../../../atoms';
 import { useEffect } from 'react';
+import { useState } from 'react';
 
 const HeaderBox = styled.header`
   width: 100%;
@@ -60,6 +63,31 @@ const Header = () => {
 
   const handleButtonClick = () => {
     navigate(-1);
+  };
+  const txtValue = useRecoilValue(postTxtValue);
+  const uploadImgSrc = useRecoilValue(uploadImgSrcAtom);
+  const onClickUploadBtn = async e => {
+    e.preventDefault();
+    try {
+      const res = await axios.post(
+        'https://mandarin.api.weniv.co.kr/post',
+        {
+          post: {
+            content: txtValue,
+            image: uploadImgSrc,
+          },
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      console.log(res);
+      const postId = res.data.post.id;
+      navigate(`/post/${postId}`);
+    } catch (error) {}
   };
 
   useEffect(() => {
@@ -165,7 +193,13 @@ const Header = () => {
                     ? 'show'
                     : null
                 }`}
-                onClick={path.includes('edit') ? onClickEditSaveBtn : null}
+                onClick={
+                  path.includes('upload')
+                    ? onClickUploadBtn
+                    : path.includes('edit')
+                    ? onClickEditSaveBtn
+                    : null
+                }
               />
             </HeaderWrapper>
           </HeaderBox>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,5 +1,0 @@
-const Login = () => {
-  return 
-};
-
-export default Login;

--- a/src/pages/PostUpload.jsx
+++ b/src/pages/PostUpload.jsx
@@ -1,5 +1,0 @@
-const PostUpload = () => {
-  return null;
-};
-
-export default PostUpload;

--- a/src/pages/PostUpload/PostUpload.jsx
+++ b/src/pages/PostUpload/PostUpload.jsx
@@ -3,13 +3,12 @@ import styled from 'styled-components';
 import Input from '../../components/atoms/Input/Input';
 import { CommonWrapper } from '../../components/common/commonWrapper';
 import Profile from '../../components/atoms/Profile/Profile';
-import FeedProfileDefault from '../../assets/feed-profile-default.png';
 import UploadImg from '../../assets/upload-file.png';
 import { useCallback, useRef, useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { postTxtValue, uploadImgSrcAtom } from '../../atoms';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { postTxtValue, profileImgSrc, uploadImgSrcAtom } from '../../atoms';
 import Img from '../../components/atoms/Img/Img';
-import ReactDOM from 'react-dom/client';
+
 const UploadWrapper = styled(CommonWrapper)`
   position: relative;
 `;
@@ -38,19 +37,16 @@ const ImgUploadLabel = styled.label`
   right: 16px;
   cursor: pointer;
 `;
-const ItemBox = styled.div`
+
+const ItemBox = styled.ul`
   display: flex;
   gap: 10px;
+  margin-top: 10px;
 `;
-const ItemDiv = styled.div`
-  width: 70px;
-  height: 50px;
-`;
-const PostUpload = () => {
-  const [propfileImgSrc, setProfileImgSrc] = useState(FeedProfileDefault);
-  const [uploadImgSrc, setUploadImgSrc] = useRecoilState(uploadImgSrcAtom);
-  // let [selctedImgs, setSelectedImgs] = useRecoilState('');
 
+const PostUpload = () => {
+  const setUploadImgSrc = useSetRecoilState(uploadImgSrcAtom);
+  const profileImg = useRecoilValue(profileImgSrc);
   const [imgSrcs, setImgSrcs] = useState([]);
 
   const uploadImg = async imgFile => {
@@ -87,8 +83,7 @@ const PostUpload = () => {
     setPostTxt(e.target.value);
   }, []);
 
-  const [postImgSrc, setPostImgSrc] = useState('');
-  const [postTxt, setPostTxt] = useRecoilState(postTxtValue);
+  const setPostTxt = useSetRecoilState(postTxtValue);
   // async나 axios로 데이터를 받아온 게 확인되면 setProfileImgSrc(user데이터의 프로필이미지 src) 하는 함수 추가
 
   let arraySelectedImgs = [];
@@ -96,18 +91,20 @@ const PostUpload = () => {
 
   const handleImgInputOnchange = async e => {
     const files = e.target.files;
-
-    Array.from(files).map(async (e, i) => {
-      const url = await uploadImg(e);
-      arraySelectedImgs.push(url);
-      setImgSrcs(prev => [...prev, url]);
-      console.log(imgSrcs);
-      console.log(arraySelectedImgs);
-    });
-    selectedImgsUrl = arraySelectedImgs.join(',');
-    setPostImgSrc(selectedImgsUrl);
+    if (files.length < 4) {
+      Array.from(files).map(async (file, i) => {
+        const url = await uploadImg(file);
+        arraySelectedImgs.push(url);
+        setImgSrcs(prev => [...prev, url]);
+        console.log(imgSrcs);
+        console.log(arraySelectedImgs);
+      });
+      selectedImgsUrl = arraySelectedImgs.join(',');
+      setUploadImgSrc(selectedImgsUrl);
+    } else {
+      window.alert('이미지는 3개까지 업로드 가능합니다.');
+    }
   };
-
   // 밑에는 헤더로 들어갈 부분!
 
   return (
@@ -116,7 +113,7 @@ const PostUpload = () => {
         <ProfileImgDiv>
           <Profile
             size='42px'
-            imgSrc={propfileImgSrc}
+            imgSrc={profileImg}
             imgAlt='피드 프로필 기본이미지'
           />
         </ProfileImgDiv>
@@ -129,7 +126,9 @@ const PostUpload = () => {
           />
           <ItemBox id='root'>
             {imgSrcs.map((imgSrc, i) => (
-              <Img key={i} width='50px' height='50px' imgSrc={imgSrc}></Img>
+              <li>
+                <Img key={i} width='80px' height='80px' imgSrc={imgSrc}></Img>
+              </li>
             ))}
           </ItemBox>
         </TextAreaDiv>


### PR DESCRIPTION
1. 포스트 업로드 기능을 구현했습니다.
2. 업로드 버튼을 누르면 입력한 텍스트와 업로드 한 이미지의 데이터가 전송되고 내가 쓴 글에 업로드 한 포스트가 저장됩니다.
3. 이미 개발된 페이지와 이름이 중복된 쓰지 않는 파일들을 제거했습니다.
4. 로그인이 되어있지 않으면 업로드, 내 프로필 페이지로 이동했을 때 로그인 페이지로 이동되는 코드를 추가했습니다.
5. 프로필이미지를 업로드 할 때 업로드 가능한 확장자 코드를 모든 이미지 파일에서 명세에 나와있는 이미지파일들로 변경하였습니다. 