### PR TITLE
FE-39 Feat : 포스트 상세페이지 구현 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import YourProfile from './pages/YourProfile';
 import Header from './components/modules/Header/Header';
 import Nav from './components/modules/Nav/Nav';
 import MyProfileEdit from './pages/MyProfileEdit/MyProfileEdit';
-import PostDetail from './pages/PostDetail';
+import PostDetail from './pages/PostDetail/PostDetail';
 import Followers from './pages/Followers/Followers';
 import { useRecoilState } from 'recoil';
 import { isLogin } from './atoms';

--- a/src/components/atoms/Icon/Icon.jsx
+++ b/src/components/atoms/Icon/Icon.jsx
@@ -19,9 +19,14 @@ const IconCss = css`
   &.list-active {
     background-position: -56px -146px;
   }
+  &.delete {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+  }
 `;
 
-const IconDiv = styled.div`
+const IconSpan = styled.span`
   ${IconCss};
   &.right {
     float: right;
@@ -61,7 +66,7 @@ const Icon = ({
       title={title}
     />
   ) : (
-    <IconDiv
+    <IconSpan
       size={size}
       xpoint={xpoint}
       ypoint={ypoint}

--- a/src/components/atoms/Input/Input.jsx
+++ b/src/components/atoms/Input/Input.jsx
@@ -18,6 +18,10 @@ const StyledInput = styled.input`
   &[type='file'] {
     border: none;
   }
+  &.input_chat-comment,
+  &[type='text'] {
+    flex-basis: 1;
+  }
   &[type='search'] {
     border: none;
     border-radius: 32px;

--- a/src/components/modules/Comment/Comment.jsx
+++ b/src/components/modules/Comment/Comment.jsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import Profile from '../../atoms/Profile/Profile';
+import Icon from '../../atoms/Icon/Icon';
+import UserProfile from '../../../assets/comment-profile.png';
+
+const CommentUserInfohWrapper = styled.div`
+  width: 100%;
+  padding: 16px 16px 0 16px;
+`;
+
+const CommentUserInfoDiv = styled.div`
+  padding: 5px 0 6px;
+  margin: 0 auto;
+  box-sizing: border-box;
+  display: flex;
+`;
+
+const CommentUserInfoUl = styled.ul`
+  width: 100%;
+  margin-left: 12px;
+`;
+
+const CommentUserInfoLi = styled.li`
+  font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  &:nth-child(1) {
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 18px;
+    margin-bottom: 6px;
+  }
+  &:nth-child(2) {
+    font-size: 14px;
+    line-height: 18px;
+    color: ${props => props.theme.color.text.gray};
+  }
+`;
+
+const CommentTime = styled.span`
+  margin-left: 6px;
+  font-weight: 400;
+  font-size: 10px;
+  line-height: 13px;
+  color: ${props => props.theme.color.gray.d4};
+`;
+
+const PostUserInfo = () => {
+  return (
+    <CommentUserInfohWrapper>
+      <CommentUserInfoDiv>
+        <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
+        <CommentUserInfoUl>
+          <CommentUserInfoLi>
+            이호준(Licat)<CommentTime>ㆍ5분전</CommentTime>
+          </CommentUserInfoLi>
+          <CommentUserInfoLi>얼꼴팀 최고최고</CommentUserInfoLi>
+        </CommentUserInfoUl>
+
+        <Icon size='18px' xpoint='-88px' ypoint='-236px' />
+      </CommentUserInfoDiv>
+    </CommentUserInfohWrapper>
+  );
+};
+
+export default PostUserInfo;

--- a/src/components/modules/Comment/Comment.jsx
+++ b/src/components/modules/Comment/Comment.jsx
@@ -3,65 +3,62 @@ import Profile from '../../atoms/Profile/Profile';
 import Icon from '../../atoms/Icon/Icon';
 import UserProfile from '../../../assets/comment-profile.png';
 
-const CommentUserInfohWrapper = styled.div`
-  width: 100%;
-  padding: 16px 16px 0 16px;
-`;
-
-const CommentUserInfoDiv = styled.div`
-  padding: 5px 0 6px;
-  margin: 0 auto;
-  box-sizing: border-box;
-  display: flex;
-`;
-
-const CommentUserInfoUl = styled.ul`
-  width: 100%;
-  margin-left: 12px;
-`;
-
 const CommentUserInfoLi = styled.li`
-  font-weight: 400;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  &:nth-child(1) {
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 18px;
-    margin-bottom: 6px;
-  }
-  &:nth-child(2) {
-    font-size: 14px;
-    line-height: 18px;
-    color: ${props => props.theme.color.text.gray};
-  }
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+`;
+const CommentTxt = styled.div`
+  width: 100%;
 `;
 
-const CommentTime = styled.span`
-  margin-left: 6px;
+const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+const Time = styled.span`
+  flex-grow: 1;
   font-weight: 400;
   font-size: 10px;
   line-height: 13px;
   color: ${props => props.theme.color.gray.d4};
 `;
 
-const PostUserInfo = () => {
-  return (
-    <CommentUserInfohWrapper>
-      <CommentUserInfoDiv>
-        <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
-        <CommentUserInfoUl>
-          <CommentUserInfoLi>
-            이호준(Licat)<CommentTime>ㆍ5분전</CommentTime>
-          </CommentUserInfoLi>
-          <CommentUserInfoLi>얼꼴팀 최고최고</CommentUserInfoLi>
-        </CommentUserInfoUl>
+const UserId = styled.strong`
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 18px;
+`;
 
-        <Icon size='18px' xpoint='-88px' ypoint='-236px' />
-      </CommentUserInfoDiv>
-    </CommentUserInfohWrapper>
+const CommentContent = styled.p`
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  margin-top: 16px;
+  padding-right: 10px;
+  word-break: keep-all;
+  word-wrap: break-word;
+`;
+
+const Comment = ({ data }) => {
+  console.log(data);
+  // 아직 댓글달기 기능이 없어서 댓글 기능 추가 후 진행예정
+  return (
+    <CommentUserInfoLi>
+      <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
+      <CommentTxt>
+        <UserInfo>
+          <UserId>도촌동 풀벌레 찌르찌르</UserId>
+          <Time>ㆍ5분전</Time>
+          <Icon size='24px' xpoint='-54px' ypoint='-192px' />
+        </UserInfo>
+        <CommentContent>
+          나도 어디서 꿀리진 않어 아무것도 난 한게 없어 너도 어디서 꿀리진 않닌
+        </CommentContent>
+      </CommentTxt>
+    </CommentUserInfoLi>
   );
 };
 
-export default PostUserInfo;
+export default Comment;

--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -10,7 +10,6 @@ import {
   accountnameValue,
   profileImgSrc,
   searchValue,
-  userDataAtom,
   userIntroValue,
   usernameValue,
   searchUserData,
@@ -18,7 +17,6 @@ import {
   uploadImgSrcAtom,
 } from '../../../atoms';
 import { useEffect } from 'react';
-import { useState } from 'react';
 
 const HeaderBox = styled.header`
   width: 100%;
@@ -32,7 +30,7 @@ const HeaderBox = styled.header`
 
 const HeaderWrapper = styled(CommonWrapper)`
   height: 48px;
-  padding: 8px 16px;
+  padding: 8px 12px 8px 16px;
   position: relative;
   display: flex;
   justify-content: space-between;

--- a/src/components/modules/Post/Post.jsx
+++ b/src/components/modules/Post/Post.jsx
@@ -8,7 +8,6 @@ import PostUserInfo from '../PostUserInfo/PostUserInfo';
 const PostWrapper = styled.article`
   width: 100%;
   padding: 4px 0px;
-  margin: 20px auto 0;
   & div:first-child {
     padding: 0;
   }
@@ -29,17 +28,22 @@ const PostText = styled.p`
 const IconContainer = styled.div`
   display: flex;
   margin-top: 12px;
+  gap: 16px;
+  /* align-items: center; */
   div {
-    margin-right: 6px;
+    vertical-align: middle;
   }
 `;
 
-const LikeCommentCount = styled.p`
+const CountNum = styled.dt`
   font-size: 12px;
-  line-height: 20px;
+  line-height: 12px;
   font-weight: 400;
+  display: inline-block;
+  vertical-align: top;
+  margin-top: 5px;
   color: ${props => props.theme.color.gray.d4};
-  margin-right: 16px;
+  margin-left: 6px;
 `;
 
 const CreatedDate = styled.p`
@@ -50,34 +54,46 @@ const CreatedDate = styled.p`
   margin-top: 16px;
 `;
 
-const Post = () => {
+const Post = ({ data }) => {
+  console.log(data);
+  const day = data.createdAt;
+  let year = day?.slice(0, 4);
+  let month = day?.slice(5, 7);
+  let date = day?.slice(8, 10);
+
   return (
     <PostWrapper>
-      <PostUserInfo />
+      <PostUserInfo author={data.author} />
       <PostContent>
-        <PostText>
-          옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
-          이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는 풍부하게
-          뛰노는 인생의 힘있다
-        </PostText>
-        <Img width='100%' imgSrc={PostImg} imgAlt='게시글 이미지' />
+        <PostText>{data.content}</PostText>
+        {data.image ? (
+          <Img width='100%' imgSrc={data.image} imgAlt='게시글 이미지' />
+        ) : null}
         <IconContainer>
-          <Icon
-            size='20px'
-            xpoint='-236px'
-            ypoint='-179px'
-            title='하트모양 아이콘'
-          />
-          <LikeCommentCount>30</LikeCommentCount>
-          <Icon
-            size='20px'
-            xpoint='-192px'
-            ypoint='-142px'
-            title='메시지 아이콘'
-          />
-          <LikeCommentCount>10</LikeCommentCount>
+          <div>
+            <dt className='ir'>좋아요</dt>
+            <Icon
+              size='20px'
+              xpoint='-236px'
+              ypoint='-179px'
+              title='하트모양 아이콘'
+            />
+            <CountNum>{data.heartCount}</CountNum>
+          </div>
+          <div>
+            <dt className='ir'>댓글</dt>
+            <Icon
+              size='20px'
+              xpoint='-192px'
+              ypoint='-142px'
+              title='메시지 아이콘'
+            />
+            <CountNum>{data.commentCount}</CountNum>
+          </div>
         </IconContainer>
-        <CreatedDate>2020년 10월 21일</CreatedDate>
+        <CreatedDate>
+          {year}년 {month}월 {date}일
+        </CreatedDate>
       </PostContent>
     </PostWrapper>
   );

--- a/src/components/modules/Post/Post.jsx
+++ b/src/components/modules/Post/Post.jsx
@@ -35,7 +35,7 @@ const IconContainer = styled.div`
   }
 `;
 
-const CountNum = styled.dt`
+const CountNum = styled.dd`
   font-size: 12px;
   line-height: 12px;
   font-weight: 400;

--- a/src/components/modules/PostCommentInput/PostCommentInput.jsx
+++ b/src/components/modules/PostCommentInput/PostCommentInput.jsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import Input from '../../atoms/Input/Input';
+import Profile from '../../atoms/Profile/Profile';
+import UserProfile from '../../../assets/basic-profile-img.png';
+import { useState } from 'react';
+
+const InputFlexContainer = styled.div`
+  display: flex;
+  gap: 18px;
+`;
+
+const InputWrap = styled.div`
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  padding: 13px 16px 12px 20px;
+  border-top: 0.5px solid ${props => props.theme.color.gray.d2};
+  background-color: white;
+`;
+
+const InputBtn = styled.button`
+  display: inline-block;
+  width: 50px;
+  color: #c4c4c4;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 18px;
+  &.active {
+    color: ${props => props.theme.color.main.green};
+  }
+`;
+
+const PostCommentInput = () => {
+  const [txt, setTxt] = useState('');
+
+  const onChangeInput = e => {
+    setTxt(e.target.value);
+  };
+  return (
+    <InputWrap>
+      <InputFlexContainer>
+        <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
+        <Input
+          className='input_chat-comment'
+          type='text'
+          placeholder='댓글 입력하기...'
+          onChange={onChangeInput}
+        />
+        <InputBtn
+          className={txt ? 'active' : null}
+          disabled={txt ? false : true}
+        >
+          게시
+        </InputBtn>
+      </InputFlexContainer>
+    </InputWrap>
+  );
+};
+
+export default PostCommentInput;

--- a/src/components/modules/PostUserInfo/PostUserInfo.jsx
+++ b/src/components/modules/PostUserInfo/PostUserInfo.jsx
@@ -39,14 +39,15 @@ const PostUserInfoLi = styled.li`
   }
 `;
 
-const PostUserInfo = () => {
+const PostUserInfo = ({ author }) => {
+  console.log(author);
   return (
     <PostUserInfohWrapper>
       <PostUserInfoDiv>
         <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
         <PostUserInfoUl>
-          <PostUserInfoLi>애월읍 위니브 감귤농장</PostUserInfoLi>
-          <PostUserInfoLi>@weniv_Mandarin</PostUserInfoLi>
+          <PostUserInfoLi>{author.username}</PostUserInfoLi>
+          <PostUserInfoLi>{author.accountname}</PostUserInfoLi>
         </PostUserInfoUl>
         <Icon size='18px' xpoint='-88px' ypoint='-236px' />
       </PostUserInfoDiv>

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,5 +1,0 @@
-const PostDetail = () => {
-  return null;
-};
-
-export default PostDetail;

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import { CommonWrapper } from '../../components/common/commonWrapper';
+import Post from '../../components/modules/Post/Post';
+import Comment from '../../components/modules/Comment/Comment';
+import Input from '../../components/atoms/Input/Input';
+import Profile from '../../components/atoms/Profile/Profile';
+import UserProfile from '../../assets/basic-profile-img.png';
+
+const Line = styled.hr`
+  width: 100%;
+  height: 1px;
+  background-color: ${props => props.theme.color.gray.d2};
+  margin-top: 20px;
+`;
+
+const CommentDiv = styled.div`
+  width: 100%;
+  display: flex;
+  padding: 13px 16px;
+  margin-top: 20px;
+  background-color: ${props => props.theme.color.text.white};
+  border-top: 0.5px solid ${props => props.theme.color.gray.d2};
+`;
+
+const CommentProfileWrapper = styled.div`
+  margin-right: 18px;
+`;
+
+const PostDetail = () => {
+  return (
+    <CommonWrapper>
+      <Post />
+      <Line />
+      <Comment />
+      <Comment />
+      <CommentDiv>
+        <CommentProfileWrapper>
+          <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
+        </CommentProfileWrapper>
+        <Input
+          className='input_chat-comment'
+          type='text'
+          placeholder='댓글 입력하기...'
+        />
+      </CommentDiv>
+    </CommonWrapper>
+  );
+};
+
+export default PostDetail;

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -2,48 +2,68 @@ import styled from 'styled-components';
 import { CommonWrapper } from '../../components/common/commonWrapper';
 import Post from '../../components/modules/Post/Post';
 import Comment from '../../components/modules/Comment/Comment';
-import Input from '../../components/atoms/Input/Input';
-import Profile from '../../components/atoms/Profile/Profile';
-import UserProfile from '../../assets/basic-profile-img.png';
+import PostCommentInput from '../../components/modules/PostCommentInput/PostCommentInput';
+import { useEffect } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
 
-const Line = styled.hr`
-  width: 100%;
-  height: 1px;
-  background-color: ${props => props.theme.color.gray.d2};
-  margin-top: 20px;
+const PostWrap = styled.div`
+  padding: 20px 16px;
+  border-bottom: 0.5px solid ${props => props.theme.color.gray.d2};
 `;
 
-const CommentDiv = styled.div`
+const CommentUl = styled.ul`
+  padding: 20px 16px;
   width: 100%;
+  height: 100%;
   display: flex;
-  padding: 13px 16px;
-  margin-top: 20px;
-  background-color: ${props => props.theme.color.text.white};
-  border-top: 0.5px solid ${props => props.theme.color.gray.d2};
-`;
-
-const CommentProfileWrapper = styled.div`
-  margin-right: 18px;
+  flex-direction: column;
+  gap: 16px;
 `;
 
 const PostDetail = () => {
+  const params = useParams();
+  const postId = params.post_id;
+  const token = localStorage.getItem('token');
+  const [postData, setPostData] = useState(null);
+
+  const setData = async () => {
+    try {
+      const res = await axios.get(
+        `https://mandarin.api.weniv.co.kr/post/${postId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      console.log(res);
+      const info = res.data.post;
+      setPostData(info);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  useEffect(() => {
+    setData();
+  }, []);
+
   return (
-    <CommonWrapper>
-      <Post />
-      <Line />
-      <Comment />
-      <Comment />
-      <CommentDiv>
-        <CommentProfileWrapper>
-          <Profile size='42px' imgSrc={UserProfile} imgAlt='프로필 이미지' />
-        </CommentProfileWrapper>
-        <Input
-          className='input_chat-comment'
-          type='text'
-          placeholder='댓글 입력하기...'
-        />
-      </CommentDiv>
-    </CommonWrapper>
+    <>
+      <CommonWrapper>
+        <PostWrap>{postData && <Post data={postData} />}</PostWrap>
+        {postData && (
+          <CommentUl>
+            {postData.comments.map(data => {
+              <Comment data={data} />;
+            })}
+          </CommentUl>
+        )}
+        <PostCommentInput />
+      </CommonWrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
1. API에서 post_id값으로 데이터를 받아와 포스트 상세페이지를 구현했습니다.
2. 데이터들을 각각 필요로 하는 컴포넌트에 props로 넘겨주었습니다.
3. input 아톰 컴포넌트에 댓글창에 필요한 클래스를 추가했습니다.
4. Post 컴포넌트에서 주고있던 패딩값을 삭제했습니다.
5. Icon 컴포넌트 내 Div태그를 Span태그로 수정했습니다.
6. delete 클래스를 추가했습니다.