### PR TITLE
FE-24 Feat : 업로드 기능 재구현 

### DIFF
--- a/src/atoms.js
+++ b/src/atoms.js
@@ -67,7 +67,7 @@ export const searchUserData = atom({
   default: [],
 });
 
-export const uploadImgSrcAtom = atom({
+export const uploadImgSrcArray = atom({
   key: 'uploadImgSrc',
-  default: '',
+  default: [],
 });

--- a/src/components/atoms/Icon/Icon.jsx
+++ b/src/components/atoms/Icon/Icon.jsx
@@ -56,6 +56,7 @@ const Icon = ({
   isLink,
   className,
   onClick,
+  id,
 }) => {
   return isLink ? (
     <IconLink
@@ -73,6 +74,7 @@ const Icon = ({
       title={title}
       className={className}
       onClick={onClick}
+      id={id}
     />
   );
 };

--- a/src/components/atoms/Input/Input.jsx
+++ b/src/components/atoms/Input/Input.jsx
@@ -45,6 +45,9 @@ const StyledTextArea = styled.textarea`
     line-height: 1;
     color: ${props => props.theme.color.gray.d3};
   }
+  &:focus {
+    outline: none;
+  }
 `;
 
 const Input = ({

--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -14,7 +14,7 @@ import {
   usernameValue,
   searchUserData,
   postTxtValue,
-  uploadImgSrcAtom,
+  uploadImgSrcArray,
 } from '../../../atoms';
 import { useEffect } from 'react';
 
@@ -62,9 +62,12 @@ const Header = () => {
   const handleButtonClick = () => {
     navigate(-1);
   };
+  // 포스트 업로드 버튼
   const txtValue = useRecoilValue(postTxtValue);
-  const uploadImgSrc = useRecoilValue(uploadImgSrcAtom);
+  const [uploadImgSrc, setuploadImgSrc] = useRecoilState(uploadImgSrcArray);
+
   const onClickUploadBtn = async e => {
+    const images = uploadImgSrc.join(', ');
     e.preventDefault();
     try {
       const res = await axios.post(
@@ -72,7 +75,7 @@ const Header = () => {
         {
           post: {
             content: txtValue,
-            image: uploadImgSrc,
+            image: images,
           },
         },
         {
@@ -85,7 +88,10 @@ const Header = () => {
       console.log(res);
       const postId = res.data.post.id;
       navigate(`/post/${postId}`);
-    } catch (error) {}
+      setuploadImgSrc([]);
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   useEffect(() => {

--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -64,7 +64,7 @@ const Header = () => {
   };
   // 포스트 업로드 버튼
   const txtValue = useRecoilValue(postTxtValue);
-  const [uploadImgSrc, setuploadImgSrc] = useRecoilState(uploadImgSrcArray);
+  const [uploadImgSrc, setUploadImgSrc] = useRecoilState(uploadImgSrcArray);
 
   const onClickUploadBtn = async e => {
     const images = uploadImgSrc.join(', ');
@@ -88,7 +88,7 @@ const Header = () => {
       console.log(res);
       const postId = res.data.post.id;
       navigate(`/post/${postId}`);
-      setuploadImgSrc([]);
+      setUploadImgSrc([]);
     } catch (error) {
       console.log(error);
     }

--- a/src/pages/EmailLogin/EmailLogin.jsx
+++ b/src/pages/EmailLogin/EmailLogin.jsx
@@ -8,6 +8,7 @@ import {
   idValue,
   isLogin,
   passwordValue,
+  profileImgSrc,
   userDataAtom,
   userIntroValue,
   usernameValue,
@@ -55,6 +56,8 @@ const EmailLogin = () => {
   const setUsername = useSetRecoilState(usernameValue);
   const setAccountname = useSetRecoilState(accountnameValue);
   const setIntro = useSetRecoilState(userIntroValue);
+  const setProfileImgSrc = useSetRecoilState(profileImgSrc);
+
   const onClickLoginBtn = async e => {
     e.preventDefault();
     try {
@@ -79,6 +82,7 @@ const EmailLogin = () => {
         setUsername(data.username);
         setAccountname(data.accountname);
         setIntro(data.intro);
+        setProfileImgSrc(data.image);
         navigate('/');
       }
     } catch (error) {


### PR DESCRIPTION
1. 전역변수로 업로드 미리보기 된 이미파일의 url을 담아놓는 배열을 만들었습니다.
2. 미리보기 된 IMG 파일에 삭제버튼을 추가했습니다.
3. 삭제기능 구현을 위해 icon 아톰 파일에 id props를 추가했습니다.
4. header에 있는 업로드 버튼을 누르면 서버에 데이터를 보내고 게시글이 로그인 된 유저의 게시글에 업로드되는 기능을 구현했습니다.
5. upload 창에서 텍스트 입력창이 focus 되었을 때 outline 효과를 제거했습니다.
6. 로그인에 성공했을 시 전역변수에 응답받은 프로필이미지의 src를 저장하는 기능을 추가했습니다.

정말 얼마 안남았군요! 모두 파이팅입니다! 😉✈🎈