### PR TITLE
FE-43 Feat : 팔로우 리스트, 팔로잉 리스트 데이터 불러오기 기능 개발

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,7 @@ function App() {
         />
         <Route path='/profile/:id/edit' element={<MyProfileEdit />} />
         <Route path='/profile/:id/follower' element={<Followers />} />
+        <Route path='/profile/:id/following' element={<Followers />} />
         <Route
           path='/profile/:id/addProduct'
           element={<MyProfileAddProduct />}

--- a/src/components/modules/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/modules/ProfileInfo/ProfileInfo.jsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 
 import Profile from '../../atoms/Profile/Profile';
 import MyProfileBtn from '../MyprofileBtn/MyProfileBtn';
@@ -123,10 +123,10 @@ const ProfileInfo = () => {
       <ProfileInfoSection>
         <CommonWrapper>
           <FollowWrap>
-            <div>
+            <Link to={`/profile/${userinfo.accountname}/follower`}>
               <FollowNum>{followerCount}</FollowNum>
               <FollowSpan>followers</FollowSpan>
-            </div>
+            </Link>
             <div>
               <Profile
                 size='110px'
@@ -134,10 +134,10 @@ const ProfileInfo = () => {
                 imgSrc={userinfo.image}
               />
             </div>
-            <div>
+            <Link to={`/profile/${userinfo.accountname}/following`}>
               <FollowNum className='gray'>{followingCount}</FollowNum>
               <FollowSpan>followings</FollowSpan>
-            </div>
+            </Link>
           </FollowWrap>
           <ProfileH1>{userinfo.username}</ProfileH1>
           <ProfileH2>@ {userinfo.accountname}</ProfileH2>

--- a/src/pages/Followers/Followers.jsx
+++ b/src/pages/Followers/Followers.jsx
@@ -2,63 +2,199 @@ import styled from 'styled-components';
 import Profile from '../../components/atoms/Profile/Profile';
 import FollwersProfile from '../../assets/comment-profile.png';
 import Button from '../../components/atoms/Button/Button';
+import { CommonWrapper } from '../../components/common/commonWrapper';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Link, useLocation, useParams } from 'react-router-dom';
 
-const FollowersWrapper = styled.div`
-  width: 100%;
-  height: 100%;
+const FollowersWrapper = styled(CommonWrapper)`
   padding: 24px 16px 0;
 `;
 
-const FollowerDiv = styled.div`
-  padding: 5px 0 6px;
-  margin: 0 auto 16px;
-  box-sizing: border-box;
+const FollowerUl = styled.ul`
   display: flex;
-`;
-
-const FollowersUl = styled.ul`
+  flex-direction: column;
+  gap: 16px;
   width: 100%;
-  margin-left: 12px;
 `;
 
-const FollowersLi = styled.li`
-  font-weight: 400;
+const FollowerLi = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+  a {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+  }
+`;
+
+const FollowerInfo = styled.div`
+  width: 280px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  &:nth-child(1) {
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 18px;
-    margin-bottom: 6px;
-  }
-  &:nth-child(2) {
-    font-size: 12px;
-    line-height: 15px;
-    color: ${props => props.theme.color.text.gray};
-  }
+`;
+
+const FollowerUserName = styled.p`
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 18px;
+  margin-bottom: 6px;
+`;
+
+const FollowerIntro = styled.p`
+  font-size: 12px;
+  line-height: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: ${props => props.theme.color.text.gray};
 `;
 
 const Followers = () => {
+  const token = localStorage.getItem('token');
+
+  const path = useLocation().pathname;
+  const { id } = useParams();
+
+  const [followData, setFollowData] = useState([]);
+  const [followChange, setFollowChange] = useState(false);
+
+  const getFollowingData = async () => {
+    try {
+      const res = await axios.get(
+        `https://mandarin.api.weniv.co.kr/profile/${id}/following/?limit=${parseInt(
+          20,
+        )}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      setFollowData(res.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const getFollowerData = async () => {
+    try {
+      const res = await axios.get(
+        `https://mandarin.api.weniv.co.kr/profile/${id}/follower/?limit=${parseInt(
+          20,
+        )}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      setFollowData(res.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleFollowBtn = async e => {
+    e.preventDefault();
+    const accountname = e.target.value;
+    try {
+      const res = await axios.post(
+        `https://mandarin.api.weniv.co.kr/profile/${accountname}/follow`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      setFollowChange(prev => !prev);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleUnfollowBtn = async e => {
+    e.preventDefault();
+    const accountname = e.target.value;
+    try {
+      const res = await axios.delete(
+        `https://mandarin.api.weniv.co.kr/profile/${accountname}/unfollow`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      setFollowChange(prev => !prev);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    if (path.includes('follower')) {
+      getFollowerData();
+    } else if (path.includes('following')) {
+      getFollowingData();
+    }
+  }, [followChange]);
+
   return (
     <FollowersWrapper>
-      <FollowerDiv>
-        <Profile size='42px' imgSrc={FollwersProfile} imgAlt='프로필 이미지' />
-        <FollowersUl>
-          <FollowersLi>한라봉의신</FollowersLi>
-          <FollowersLi>30년 노하우로 정성스럽게 농사지은 한라봉</FollowersLi>
-        </FollowersUl>
-        <Button
-          label='팔로우'
-          fontSize='12px'
-          fontWeight='400'
-          lineHeight='15px'
-          padding='11px 7px'
-          bgColor={props => props.theme.color.main.green}
-          txtColor={props => props.theme.color.text.white}
-          borderRadius='26px'
-        />
-      </FollowerDiv>
+      <FollowerUl>
+        {followData.map(followData => (
+          <FollowerLi key={followData._id}>
+            <Link to={`/yourProfile/${followData.accountname}`}>
+              <Profile
+                size='50px'
+                imgSrc={followData.image}
+                imgAlt='프로필 이미지'
+                borderRadius={props => props.theme.borderRadius.circle}
+              />
+              <FollowerInfo>
+                <FollowerUserName>{followData.username}</FollowerUserName>
+                <FollowerIntro>{followData.intro}</FollowerIntro>
+              </FollowerInfo>
+            </Link>
+            {followData.isfollow ? (
+              <Button
+                label='취소'
+                fontSize='12px'
+                fontWeight='400'
+                lineHeight='15px'
+                padding='7px 0'
+                borderRadius='26px'
+                className='btn_active'
+                value={followData.accountname}
+                onClick={handleUnfollowBtn}
+              />
+            ) : (
+              <Button
+                label='팔로우'
+                fontSize='12px'
+                fontWeight='400'
+                lineHeight='15px'
+                padding='7px 0'
+                bgColor={props => props.theme.color.main.green}
+                txtColor={props => props.theme.color.text.white}
+                borderRadius='26px'
+                value={followData.accountname}
+                onClick={handleFollowBtn}
+              />
+            )}
+          </FollowerLi>
+        ))}
+      </FollowerUl>
     </FollowersWrapper>
   );
 };


### PR DESCRIPTION
1. 팔로잉 리스트를 볼 수 있는 페이지를 추가했습니다.
2. ProfileInfo 내에 followers, followings를 누르면 팔로우 리스트, 팔로잉 리스트 페이지로 갈 수 있게 링크를 걸었습니다.
3. following, follower api를 사용해 불러온 데이터를 활용해 페이지를 구성했습니다.
4. followChange 값을 state로 줘서 팔로우, 취소 버튼을 클릭할 때마다 불리언 값이 바뀌게 설정해줘서 바뀔때마다 리렌더링이 일어나 데이터가 최신화되게 했습니다.
5. path 값에 follower가 들어오면 follower 데이터를 following이 들어가면 following 데이터를 받아오게 했습니다.