### PR TITLE
FE-46 Feat : 게시물 수정 기능

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,7 +74,7 @@ function App() {
           }
         />
         <Route
-          path='upload/:postId'
+          path='/upload/:postId'
           element={
             isLoginState ? (
               <PostUpload />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,7 +64,17 @@ function App() {
         />
         <Route path='/post/:id' element={<PostDetail />} />
         <Route
-          path='/upload'
+          path='/upload/'
+          element={
+            isLoginState ? (
+              <PostUpload />
+            ) : (
+              <Navigate replace={true} to='/login' />
+            )
+          }
+        />
+        <Route
+          path='upload/:postId'
           element={
             isLoginState ? (
               <PostUpload />

--- a/src/components/modules/DropUp/DropUp.jsx
+++ b/src/components/modules/DropUp/DropUp.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Overlay = styled.div`
@@ -32,14 +33,25 @@ const DropUpLi = styled.li`
   font-size: 14px;
 `;
 
-const DropUp = ({ menu, setDropUpShow, setModalShow }) => {
+const DropUp = ({ menu, setDropUpShow, setModalShow, postId }) => {
+  const navigate = useNavigate();
+  const onClickPostEdit = () => {
+    console.log(postId);
+    // 밑의 함수가 작동하지 않습니다.
+    navigate(`/upload/${postId}`);
+  };
   return (
     <Overlay onClick={() => setDropUpShow(false)}>
       <DropUpWrapper>
         <DragBar />
         <ul>
           {menu.map((item, index) => (
-            <DropUpLi onClick={() => setModalShow(true)} key={index}>
+            <DropUpLi
+              onClick={
+                item === '수정하기' ? onClickPostEdit : () => setModalShow(true)
+              }
+              key={index}
+            >
               {item}
             </DropUpLi>
           ))}

--- a/src/components/modules/DropUp/DropUp.jsx
+++ b/src/components/modules/DropUp/DropUp.jsx
@@ -1,6 +1,14 @@
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
+const scrollUp = keyframes`
+  0% {
+    transform: translateY(130px)
+  }
+  100% {
+    transform: translateY(0)
+  }
+`;
 const Overlay = styled.div`
   position: fixed;
   top: 0;
@@ -19,6 +27,7 @@ const DropUpWrapper = styled.div`
   overflow: auto;
   border-radius: 10px 10px 0 0;
   background-color: #fff;
+  animation: ${scrollUp} 0.5s ease-in-out;
 `;
 const DragBar = styled.div`
   width: 50px;
@@ -37,7 +46,6 @@ const DropUp = ({ menu, setDropUpShow, setModalShow, postId }) => {
   const navigate = useNavigate();
   const onClickPostEdit = () => {
     console.log(postId);
-    // 밑의 함수가 작동하지 않습니다.
     navigate(`/upload/${postId}`);
   };
   return (

--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Icon from '../../atoms/Icon/Icon';
 import Button from '../../atoms/Button/Button';
@@ -126,7 +126,7 @@ const Header = () => {
       );
       console.log(res);
       const postId = res.data.post.id;
-      navigate(`/post/${postId}`);
+      navigate(`/post/${postId}`, { replace: true });
       setUploadImgSrc([]);
     } catch (error) {
       console.log(error);
@@ -177,14 +177,41 @@ const Header = () => {
       setAccountname(data.accountname);
       setIntro(data.intro);
       setProfileImgSrcValue(data.image);
-      console.log(res);
-      console.log(data);
     } catch (error) {
       console.log(error);
     }
     navigate(`/profile/${accountname}`);
   };
 
+  // 포스트 수정 함수
+  const postId = useParams();
+  const editPostBtn = async e => {
+    const images = uploadImgSrc.join(', ');
+    e.preventDefault();
+    try {
+      const res = await axios.post(
+        `https://mandarin.api.weniv.co.kr/post/${postId}`,
+        {
+          post: {
+            content: txtValue,
+            image: images,
+          },
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      console.log(res);
+      const postId = res.data.post.id;
+      navigate(`/post/${postId}`, { replace: true });
+      setUploadImgSrc([]);
+    } catch (error) {
+      console.log(error);
+    }
+  };
   return (
     <>
       {!path.includes('login') ? (
@@ -221,7 +248,13 @@ const Header = () => {
                 }`}
               />
               <Button
-                label={path.includes('upload') ? '업로드' : '저장'}
+                label={
+                  postId && path.includes('upload')
+                    ? '수정'
+                    : path.includes('upload')
+                    ? '업로드'
+                    : '저장'
+                }
                 fontSize='14px'
                 fontWeight='500'
                 lineHeight='18px'
@@ -241,7 +274,9 @@ const Header = () => {
                     : null
                 } + ${txtValue && uploadImgSrc ? 'btn_next' : null}`}
                 onClick={
-                  path.includes('upload')
+                  postId && path.includes('upload')
+                    ? editPostBtn
+                    : path.includes('upload')
                     ? onClickUploadBtn
                     : path.includes('edit')
                     ? onClickEditSaveBtn

--- a/src/components/modules/Modal/Modal.jsx
+++ b/src/components/modules/Modal/Modal.jsx
@@ -50,35 +50,18 @@ const Modal = ({
   btnLeft,
   btnRight,
   setModalShow,
+  excutfunc,
   setCommentList,
   postId,
   commentId,
   isMy,
 }) => {
-  const token = localStorage.getItem('token');
-  const removeComment = async () => {
-    try {
-      const res = await axios.delete(
-        `https://mandarin.api.weniv.co.kr/post/${postId}/comments/${commentId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-type': 'application/json',
-          },
-        },
-      );
-      console.log(res.data);
-      setCommentList();
-    } catch (error) {
-      console.log(error);
-    }
-  };
   return (
     <Overlay onClick={() => setModalShow(false)}>
       <ModalBox>
         <ModalTit>{title}</ModalTit>
         <ModalButtons>
-          <ModalBtn className='caution' onClick={isMy ? removeComment : null}>
+          <ModalBtn className='caution' onClick={excutfunc}>
             {btnLeft}
           </ModalBtn>
           <VerticalBar />

--- a/src/components/modules/Post/Post.jsx
+++ b/src/components/modules/Post/Post.jsx
@@ -155,7 +155,7 @@ const Post = ({ data }) => {
       {postData?.map(postData => (
         <li key={postData.id}>
           <Link to={`/yourProfile/${postData.author.accountname}`}>
-            <PostUserInfo author={postData.author} />
+            <PostUserInfo author={postData.author} postId={postData.id} />
           </Link>
           <PostContent>
             {!path.includes('post') ? (

--- a/src/components/modules/PostUserInfo/PostUserInfo.jsx
+++ b/src/components/modules/PostUserInfo/PostUserInfo.jsx
@@ -92,7 +92,7 @@ const PostUserInfo = ({ author, postId }) => {
 
       <div className={dropUpShow ? null : 'hide'}>
         <DropUp
-          menu={['삭제하기', '수정하기']}
+          menu={isMy ? ['삭제하기', '수정하기'] : ['신고하기']}
           setDropUpShow={setDropUpShow}
           setModalShow={setModalShow}
           postId={postId}

--- a/src/components/modules/PostUserInfo/PostUserInfo.jsx
+++ b/src/components/modules/PostUserInfo/PostUserInfo.jsx
@@ -1,6 +1,13 @@
 import styled from 'styled-components';
 import Profile from '../../atoms/Profile/Profile';
 import Icon from '../../atoms/Icon/Icon';
+import DropUp from '../DropUp/DropUp';
+import Modal from '../Modal/Modal';
+import { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { accountnameValue } from '../../../atoms';
 
 const PostUserInfoWrapper = styled.div`
   width: 100%;
@@ -32,7 +39,35 @@ const PostUserInfoLi = styled.li`
   }
 `;
 
-const PostUserInfo = ({ author }) => {
+const PostUserInfo = ({ author, postId }) => {
+  const [dropUpShow, setDropUpShow] = useState(false);
+  const [modalShow, setModalShow] = useState(false);
+  const [isMy, setIsMy] = useState();
+  const accountname = useRecoilValue(accountnameValue);
+
+  const handleMoreIcon = () => {
+    setIsMy(author.accountname === accountname);
+    setDropUpShow(true);
+  };
+  const token = localStorage.getItem('token');
+  const navigate = useNavigate();
+  const removePost = async () => {
+    try {
+      const res = await axios.delete(
+        `https://mandarin.api.weniv.co.kr/post/${postId}/`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      console.log(res.data);
+      navigate(`/profile/${accountname}`);
+    } catch (error) {
+      console.log(error);
+    }
+  };
   return (
     <PostUserInfoWrapper>
       <PostUserInfoDiv>
@@ -46,8 +81,32 @@ const PostUserInfo = ({ author }) => {
           <PostUserInfoLi>{author.username}</PostUserInfoLi>
           <PostUserInfoLi>{`@ ${author.accountname}`}</PostUserInfoLi>
         </PostUserInfoUl>
-        <Icon size='18px' xpoint='-88px' ypoint='-236px' />
+        <Icon
+          size='18px'
+          xpoint='-88px'
+          ypoint='-236px'
+          title='더보기 아이콘'
+          onClick={handleMoreIcon}
+        />
       </PostUserInfoDiv>
+
+      <div className={dropUpShow ? null : 'hide'}>
+        <DropUp
+          menu={['삭제하기', '수정하기']}
+          setDropUpShow={setDropUpShow}
+          setModalShow={setModalShow}
+          postId={postId}
+        />
+      </div>
+      <div className={modalShow ? null : 'hide'}>
+        <Modal
+          title={isMy ? '게시글을 삭제할까요?' : '게시글을 신고할까요?'}
+          btnLeft={isMy ? '삭제' : '신고'}
+          btnRight='취소'
+          setModalShow={setModalShow}
+          excutfunc={isMy ? removePost : null}
+        />
+      </div>
     </PostUserInfoWrapper>
   );
 };

--- a/src/components/modules/ProfilePost/ProfilePost.jsx
+++ b/src/components/modules/ProfilePost/ProfilePost.jsx
@@ -10,7 +10,7 @@ const ViewWrapper = styled(CommonWrapper)`
   padding: 0px 16px;
 `;
 const ViewPostWrapper = styled(ViewWrapper)`
-  padding-bottom: 58px;
+  padding: 12px 16px 92px;
 `;
 const ViewBtnDiv = styled.div`
   width: 100%;

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -79,7 +79,6 @@ const PostDetail = () => {
   const clickedComment = useRef();
   const [isMy, setIsMy] = useState(false);
   const [commentId, setCommentId] = useState('');
-
   const removeComment = async () => {
     try {
       const res = await axios.delete(
@@ -97,7 +96,6 @@ const PostDetail = () => {
       console.log(error);
     }
   };
-
   return (
     <>
       <CommonWrapper>
@@ -119,9 +117,10 @@ const PostDetail = () => {
         <PostCommentInput postId={id} setCommentList={setCommentList} />
         <div className={dropUpShow ? '' : 'hide'}>
           <DropUp
-            menu={isMy ? ['삭제하기'] : ['신고하기']}
+            menu={isMy ? ['삭제하기', '수정하기'] : ['신고하기']}
             setDropUpShow={setDropUpShow}
             setModalShow={setModalShow}
+            postId={id}
           />
         </div>
         <div className={modalShow ? '' : 'hide'}>

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -79,6 +79,25 @@ const PostDetail = () => {
   const clickedComment = useRef();
   const [isMy, setIsMy] = useState(false);
   const [commentId, setCommentId] = useState('');
+
+  const removeComment = async () => {
+    try {
+      const res = await axios.delete(
+        `https://mandarin.api.weniv.co.kr/post/${id}/comments/${commentId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
+      console.log(res.data);
+      setCommentList();
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <>
       <CommonWrapper>
@@ -115,6 +134,7 @@ const PostDetail = () => {
             setCommentList={setCommentList}
             postId={id}
             commentId={commentId}
+            excutfunc={removeComment}
           />
         </div>
       </CommonWrapper>


### PR DESCRIPTION
1. 모달함수를 더 유연하게 사용하기 위해 모달함수 밖에서 props로 삭제함수를 넘겨주는 방식으로 변경했습니다.
2. 포스트를 수정하는 페이지의 Router를 추가했습니다.
3. header에 포스트를 수정한 후 서버에 전송하는 함수를 추가했습니다.
4. 포스트 수정 페이지에서 버튼에 '수정' 텍스트가 뜨게 수정했습니다.
5. 상위 컴포넌트에서 모달 컴포넌트로 실행함수를 넘겨주는 방식으로 변경했습니다.
6.  게시물을 수정할 수 있는 기능을 추가했습니다.
7. 게시물의 더보기 아이콘을 클릭하면 수정하기 버튼이 DropUp으로 화면에 보입니다.
8. 수정하기 버튼을 클릭하면 해당 포스트의 수정페이지로 이동합니다.
9. DropUp창이 부드럽게 밑에서부터 올라올 수 있게 애니메이션을 추가했습니다.
10. Router에 게시글 수정 링크 맨 앞에 '/'를 추가했습니다.
11. 다른 유저가 작성 한 게시글의 더보기 아이콘을 누르면 신고하기 메뉴가 뜰 수 있게 수정했습니다.
