### PR TITLE
FE-49 Fix : 프로필수정 에러 해결

### DIFF
--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -165,17 +165,26 @@ const Header = () => {
     setSearchValue(e.target.value);
   };
 
-  const onClickEditSaveBtn = async e => {
+  const onClickProfileEditSaveBtn = async e => {
     e.preventDefault();
     try {
-      const res = await axios.put('https://mandarin.api.weniv.co.kr/user', {
-        user: {
-          username: username,
-          accountname: accountname,
-          intro: userIntro,
-          image: profileImgSrcValue,
+      const res = await axios.put(
+        'https://mandarin.api.weniv.co.kr/user',
+        {
+          user: {
+            username: username,
+            accountname: accountname,
+            intro: userIntro,
+            image: profileImgSrcValue,
+          },
         },
-      });
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+          },
+        },
+      );
       let data = res.data.user;
       setUsername(data.username);
       setAccountname(data.accountname);
@@ -297,7 +306,7 @@ const Header = () => {
                     : path.includes('upload')
                     ? onClickUploadBtn
                     : path.includes('edit')
-                    ? onClickEditSaveBtn
+                    ? onClickProfileEditSaveBtn
                     : path.includes('addProduct')
                     ? onClickPostUploadBtn
                     : null

--- a/src/components/modules/Header/Header.jsx
+++ b/src/components/modules/Header/Header.jsx
@@ -222,6 +222,7 @@ const Header = () => {
   const setIsLogin = useSetRecoilState(isLogin);
   const logoutFunc = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('recoil-persist');
     setIsLogin(false);
     navigate('/');
   };

--- a/src/pages/MyProfileEdit/MyProfileEdit.jsx
+++ b/src/pages/MyProfileEdit/MyProfileEdit.jsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import {
@@ -32,7 +33,7 @@ const MyProfileEdit = () => {
   const [isUsernameValid, setIsUsernameValid] = useState(false);
   const [usernameErrMsg, setUsernameErrMsg] = useState('');
   const userIntro = useRecoilValue(userIntroValue);
-  // const token = useRecoilValue(userDataAtom);
+  const { id } = useParams();
 
   const accountnameValidate = async () => {
     try {
@@ -60,9 +61,7 @@ const MyProfileEdit = () => {
       }
       setAccountnameErrMsg(msg);
       // 현재 본인 username일 때는 에러메시지 안뜨게 처리
-      const oldAccountName = userData.accountname;
-      if (oldAccountName === accountname) {
-        console.log(oldAccountName === accountname);
+      if (id === accountname) {
         setAccountnameErrMsg(null);
       }
     } catch (error) {
@@ -79,7 +78,6 @@ const MyProfileEdit = () => {
       setUsernameErrMsg('올바른 사용자이름이 아닙니다.');
     }
   };
-  const userData = useRecoilValue(userDataAtom);
   useEffect(() => {
     accountnameValidate();
   }, [accountname]);


### PR DESCRIPTION
1. 원래 accountname과 같아도 에러메시지가 뜨는 것을 막기 위해 전역변수 값과 input value값을 비교할 수 있게 코드를 수정했습니다.
2. 로그아웃 시 로컬스토리지에 저장 된 recoil-persist도 삭제될 수 있게 코드를 추가했습니다.
3. 함수에 headers 부분이 누락되어 있어 추가했습니다.