### PR TITLE
FE-57 Fix : 배포 페이지 내 새로고침시 페이지를 찾을 수 없는 오류 해결

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -47,7 +47,7 @@ root.render(
   <React.StrictMode>
     <RecoilRoot>
       <ThemeProvider theme={mainTheme}>
-        <Router>
+        <Router basename={process.env.public_url}>
           <GlobalStyle />
           <App />
         </Router>


### PR DESCRIPTION
1. basename을 public url 로 설정했습니다.